### PR TITLE
feat: hold updates 3 days so automerges pass the CI release-age policy

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,8 @@
   "labels": [
     "dependencies"
   ],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Problem

Products extending this preset enforce a pnpm **supply-chain policy**
(`minimumReleaseAge = 1 day`, via `pnpm-workspace.yaml`) that **rejects lockfile
entries for packages published too recently**. But this preset **automerges**
`@angular/*`, `@nx/*`, `eslint`, `@types/*`, etc. **immediately** on release.

Result: Renovate merges a patch that is younger than the 1-day pnpm gate, and the
**very next CI deploy fails at the install step** with:

```
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION — N lockfile entries failed verification:
  eslint@9.39.5 was published … within the minimumReleaseAge cutoff …
```

This just bit **`renewon`** (three failed deploy runs — Angular 21.2.18/21.2.19,
nx 22.7.6, then eslint 9.39.5, each freshly published), and will hit **every**
product on its next auto-merged bump.

## Fix

Add a top-level **`minimumReleaseAge: "3 days"`** (comfortably above the products'
1-day pnpm gate) plus **`internalChecksFilter: "strict"`** so Renovate holds a PR
until the release is old enough to install cleanly. No per-rule `automerge`
changes are needed — the existing automerge rules now simply wait out the age
gate first.

3 days (vs. exactly 1) gives margin for registry/CI clock skew and the usual
supply-chain benefit of not adopting a release in its first hours.

## Blast radius

Every repo extending `github>sneat-co/sneat-renovate-nx` (renewon, remindius,
and the sneat-ext-template-derived products). Behaviour change: automerges are
delayed ~3 days; nothing else changes.
